### PR TITLE
Clarify operational requirements and make Ollama optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This project is a manifestation of structured data extraction and semantic synth
 To effectively interact with the codebase, your local environment must support the following substrates:
 
 - **Node.js 20+**: The fundamental runtime for our operations.
-- **Ollama**: Essential for local embedding generation and RAG-based reasoning.
+- **Ollama (Optional)**: Required for local embedding generation and RAG-based reasoning.
   - `ollama pull nomic-embed-text` (for semantic vectors)
   - `ollama pull deepseek-r1` (for generative synthesis)
 - **Playwright**: Our interface for navigating the complexities of the web.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - [Key Features](#key-features)
 - [Environment Setup Guide](#environment-setup-guide)
   * [1. Install Node.js (The Engine)](#1-install-nodejs-the-engine)
-  * [2. Install Ollama (The AI Intelligence)](#2-install-ollama-the-ai-intelligence)
+  * [2. Install Ollama (Optional - For AI Intelligence)](#2-install-ollama-optional---for-ai-intelligence)
   * [3. Download and Prepare the Project](#3-download-and-prepare-the-project)
 - [Configuration](#configuration)
   * [Key Environment Variables](#key-environment-variables)
@@ -62,14 +62,16 @@ We recommend using a version manager to install Node.js. This allows you to easi
      nvm use 20
      ```
 - **macOS / Linux**:
-  1. Install `nvm` by following the instructions at [nvm.sh](https://github.com/nvm-sh/nvm).
+  1. Install `nvm` by following the instructions at [nvm.sh](https://nvm.sh).
   2. Run:
      ```bash
      nvm install 20
      nvm use 20
      ```
 
-### 2. Install Ollama (The AI Intelligence)
+### 2. Install Ollama (Optional - For AI Intelligence)
+
+Ollama is **optional**. It is only required if you want to use the Semantic Search or RAG (Retrieval-Augmented Generation) features. Basic extraction and keyword search work without it.
 
 1. Download and install Ollama from [ollama.ai](https://ollama.ai).
 2. Open your terminal and pull the required models:
@@ -99,6 +101,7 @@ cp .env.example .env
 
 ### Key Environment Variables
 
+- **HEADLESS**: Set to `false` in your `.env` file. **Note:** Headless mode (`true`) is currently non-functional due to Cloudflare Turnstile protection on Perplexity.ai. Using headful mode allows you to complete any challenges manually if they appear.
 - **OLLAMA_URL**: Access point for your local AI engine (default: http://localhost:11434).
 - **OLLAMA_MODEL**: Cognitive model for RAG synthesis (e.g., deepseek-r1).
 - **OLLAMA_EMBED_MODEL**: Model for generating vector representations (e.g., nomic-embed-text).
@@ -116,6 +119,7 @@ npm run dev
 ### Operational Directives
 
 - **Start scraper (Library)**: Initiates extraction. Authenticate manually if required.
+  - **Note**: Due to the complexity of Perplexity's API and potential network fluctuations, it may be necessary to **run the scraper multiple times** to ensure all conversations are fully gathered. The system uses checkpoints to resume where it left off.
 - **Search conversations**: Interface with your history using various modes:
   - **Auto**: Heuristic selection between semantic and exact search.
   - **Semantic**: Fuzzy matching via high-dimensional vector space.

--- a/src/repl/commands.ts
+++ b/src/repl/commands.ts
@@ -88,7 +88,7 @@ export class CommandHandler {
           await this.conversationSearchOrchestrator.validateVectorSearch()
         } catch (_error) {
           if (searchMode === 'auto') {
-            logger.warn('Vector search not available, falling back to exact text search.')
+            logger.warn('Ollama is not available (required for semantic features). Falling back to Exact Text search (ripgrep).')
             searchMode = 'rg'
           } else {
             const errorMessage = _error instanceof Error ? _error.message : String(_error)

--- a/src/repl/commands.ts
+++ b/src/repl/commands.ts
@@ -74,7 +74,7 @@ export class CommandHandler {
 
   async handleSearchWizard(): Promise<void> {
     const searchQuery = await this.promptForSearchQuery()
-    const searchMode = await this.promptForSearchMode()
+    let searchMode = (await this.promptForSearchMode()) as 'auto' | 'vector' | 'rg' | 'rag'
     const ripgrepSearchOptions = {
       pattern: searchQuery,
       caseSensitive: false,
@@ -82,17 +82,28 @@ export class CommandHandler {
       regex: false,
     }
 
-    logger.info(`Searching for: "${searchQuery}" (mode: ${searchMode})\n`)
-
     try {
-      const vectorEnabledModes = ['vector', 'auto', 'rag']
-      if (vectorEnabledModes.includes(searchMode)) {
-        await this.ensureVectorSearchIsAvailable(searchMode)
+      if (searchMode === 'auto' || searchMode === 'vector' || searchMode === 'rag') {
+        try {
+          await this.conversationSearchOrchestrator.validateVectorSearch()
+        } catch (_error) {
+          if (searchMode === 'auto') {
+            logger.warn('Vector search not available, falling back to exact text search.')
+            searchMode = 'rg'
+          } else {
+            const errorMessage = _error instanceof Error ? _error.message : String(_error)
+            logger.error(errorMessage)
+            logger.info('Start Ollama with the embedding model, then run "vectorize".')
+            return
+          }
+        }
       }
+
+      logger.info(`Searching for: "${searchQuery}" (mode: ${searchMode})\n`)
 
       await this.conversationSearchOrchestrator.search(
         searchQuery,
-        searchMode as 'auto' | 'vector' | 'rg' | 'rag',
+        searchMode,
         ripgrepSearchOptions
       )
     } catch (_error) {
@@ -240,19 +251,6 @@ export class CommandHandler {
       ],
       default: 'auto',
     })
-  }
-
-  private async ensureVectorSearchIsAvailable(mode: string): Promise<void> {
-    if (mode === 'rg') return
-
-    try {
-      await this.conversationSearchOrchestrator.validateVectorSearch()
-    } catch (_error) {
-      const errorMessage = _error instanceof Error ? _error.message : String(_error)
-      logger.error(errorMessage)
-      logger.info('Start Ollama with the embedding model, then run "vectorize".')
-      throw new CommandHandler.ValidationError(errorMessage)
-    }
   }
 
   private async handleVectorSearchValidationRetry(error: unknown): Promise<void> {

--- a/src/repl/help.ts
+++ b/src/repl/help.ts
@@ -4,30 +4,30 @@ import { logger } from '../utils/logger.js'
 export function showHelp(): void {
   logger.info(chalk.bold('\n📚 Available Actions:\n'))
 
-  logger.info(chalk.cyan('  start'))
+  logger.info(chalk.cyan('  Start scraper (Library)'))
   logger.info(
     '    Run the scraper to export your Perplexity history. If a checkpoint exists, you can resume or restart.\n'
   )
 
-  logger.info(chalk.cyan('  search'))
+  logger.info(chalk.cyan('  Search conversations'))
   logger.info(
     '    Search through exported conversations using various modes: auto, semantic, RAG, or exact text.\n'
   )
 
-  logger.info(chalk.cyan('  vectorize'))
+  logger.info(chalk.cyan('  Build vector index'))
   logger.info(
     '    Build or update the local vector index from your exports to enable semantic search and RAG.\n'
   )
 
-  logger.info(chalk.cyan('  reset'))
+  logger.info(chalk.cyan('  Reset all data'))
   logger.info(
     '    Remove all stored checkpoints, authentication data, and the vector index to start fresh.\n'
   )
 
-  logger.info(chalk.cyan('  help'))
+  logger.info(chalk.cyan('  Help'))
   logger.info('    Display this help overview.\n')
 
-  logger.info(chalk.cyan('  exit'))
+  logger.info(chalk.cyan('  Exit'))
   logger.info('    Close the application.\n')
 
   logger.info(chalk.bold('💡 Search & RAG Tips:\n'))


### PR DESCRIPTION
Updated README.md and CONTRIBUTING.md to clarify that headless mode is currently blocked by Cloudflare and that multiple runs may be required to fetch all conversations. Also explicitly marked Ollama as optional and implemented a fallback to exact (ripgrep) search in the REPL when Ollama is unavailable.

---
*PR created automatically by Jules for task [7831174595644454441](https://jules.google.com/task/7831174595644454441) started by @simwai*