### PR TITLE
fix(scraper): handle paginated API responses and improve diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,4 +42,4 @@ body:
     id: screenshots
     attributes:
       label: 'Visual Evidence (Screenshots/Logs)'
-      description: 'Provide any additional data points to help us triangulate the issue.'
+      description: 'Provide any additional data points to help us triangulate the issue. If you encountered a scraping failure, please attach the `debug/api-diagnostics.jsonl` file (it contains NO sensitive data).'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description
+Describe the changes introduced by this PR.
+
+## Related Issues
+Fixes #
+
+## Checklist
+- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] I have updated the documentation accordingly
+- [ ] I have added tests to cover my changes
+- [ ] All new and existing tests passed
+
+## Diagnostic Logs
+If this PR addresses scraping issues, did you check `debug/api-diagnostics.jsonl`? (Please do NOT share sensitive information from the logs).

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 .aider*
 *.old
 exports*
+debug/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [RAG Capabilities](#rag-capabilities)
 - [Architecture & Deep Dive](#architecture--deep-dive)
   * [Project Structure](#project-structure)
+- [Diagnostics](#diagnostics)
 - [Testing](#testing)
 
 <!-- tocstop -->
@@ -148,7 +149,11 @@ For a detailed look at our RAG implementation, hybrid search strategy, and theor
 - **src/scraper/**: Playwright-based extraction logic and parallel worker pool management.
 - **src/search/**: Vector storage (Vectra) and ripgrep search implementation.
 - **src/repl/**: Interactive CLI components.
-- **src/utils/**: Shared utility functions for data chunking and logging.
+- **src/utils/**: Shared utility functions for data chunking, logging, and API diagnostics.
+
+## Diagnostics
+
+If the scraper encounters unexpected API response formats or empty conversation entries, it logs detailed (but non-sensitive) diagnostic information to `debug/api-diagnostics.jsonl`. This file helps maintain architectural resilience by providing insights into Perplexity's evolving API without compromising user privacy.
 
 ## Testing
 

--- a/src/repl/commands.ts
+++ b/src/repl/commands.ts
@@ -59,6 +59,7 @@ export class CommandHandler {
       await this.executeFullScrapingFlow()
     } catch (_error) {
       logger.error('Scraper failed:', _error instanceof Error ? _error : String(_error))
+      logger.info('\nNote: Check "debug/api-diagnostics.jsonl" for details if the failure is related to API response changes.')
     }
   }
 
@@ -180,6 +181,9 @@ export class CommandHandler {
       await this.runExtractionPhase(browserManager, pendingConversations)
 
       logger.success('\n✨ Export complete!')
+      logger.info(
+        '\nNote: If some conversations were missed or the format looks wrong, please check "debug/api-diagnostics.jsonl" and consider opening a GitHub issue with that file attached.'
+      )
     } catch (_error) {
       throw new CommandHandler.ScraperError(
         `Scraping failed: ${_error instanceof Error ? _error.message : String(_error)}`

--- a/src/scraper/conversation-extractor.ts
+++ b/src/scraper/conversation-extractor.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page, Response } from '@playwright/test'
 import { waitStrategy } from '../utils/wait-strategy.js'
 import { logger } from '../utils/logger.js'
 import { z } from 'zod'
+import { ApiDiagnosticsWriter } from '../utils/api-diagnostics.js'
 
 export interface ExtractedConversation {
   id: string
@@ -36,8 +37,13 @@ export class ConversationExtractor {
   private static readonly ApiResponseSchema = z.union([
     z.array(ConversationExtractor.EntrySchema),
     z.object({
-      status: z.string().optional(),
       entries: z.array(ConversationExtractor.EntrySchema),
+      background_entries: z.array(z.unknown()).optional(),
+      collection_info: z
+        .object({
+          has_next_page: z.boolean().optional(),
+        })
+        .optional(),
     }),
   ])
 
@@ -149,14 +155,20 @@ export class ConversationExtractor {
   }
 
   private captureConversationApiResponse(page: Page): Promise<any> {
+    let allEntries: any[] = []
     let resolved = false
 
     return new Promise((resolve) => {
       const timeout = setTimeout(() => {
         if (!resolved) {
-          logger.warn('API response timeout – resolving with null')
+          if (allEntries.length > 0) {
+            logger.info(`API response timeout – resolving with ${allEntries.length} accumulated entries`)
+            resolve({ entries: allEntries })
+          } else {
+            logger.warn('API response timeout – resolving with null')
+            resolve(null)
+          }
           resolved = true
-          resolve(null)
         }
       }, 30000)
 
@@ -166,12 +178,7 @@ export class ConversationExtractor {
         const url = response.url()
         if (!url.includes('/rest/thread/') || url.includes('list_ask_threads')) return
 
-        logger.info(`Found matching thread API response: ${url}`)
-
-        if (page.isClosed()) {
-          logger.warn('Page is closed – cannot read response body')
-          return
-        }
+        if (page.isClosed()) return
 
         try {
           const json = await response.json()
@@ -179,15 +186,28 @@ export class ConversationExtractor {
 
           const parseResult = ConversationExtractor.ApiResponseSchema.safeParse(json)
           if (!parseResult.success) {
-            logger.warn(`API response validation failed: ${parseResult.error.message}`)
-          }
+            ApiDiagnosticsWriter.writeFailure({
+              url: response.url(),
+              errorType: 'zod_error',
+              zodErrorPaths: parseResult.error.issues.map((e) => e.path.join('.')),
+            }).catch(() => {})
+          } else {
+            const data = parseResult.data
+            const currentEntries = Array.isArray(data) ? data : data.entries
+            allEntries.push(...currentEntries)
 
-          clearTimeout(timeout)
-          resolved = true
-          resolve(json)
+            const hasNextPage = !Array.isArray(data) && data.collection_info?.has_next_page === true
+            if (!hasNextPage) {
+              clearTimeout(timeout)
+              resolved = true
+              resolve({ entries: allEntries })
+            } else {
+              logger.info(`Captured paginated response, ${allEntries.length} entries so far...`)
+            }
+          }
         } catch (_error) {
-          if (resolved) return
-          logger.error(`Failed to parse JSON from thread API: ${_error}`)
+          // Silent catch for JSON parse errors from other non-JSON responses
+          // or if the response was already consumed/closed.
         }
       })
     })
@@ -224,7 +244,7 @@ export class ConversationExtractor {
 
   private parseConversationData(data: any, url: string): ExtractedConversation | null {
     try {
-      const entries = this.ensureEntriesFormat(data)
+      const entries = this.ensureEntriesFormat(data, url)
 
       const parseResult = z
         .array(ConversationExtractor.EntrySchema)
@@ -232,6 +252,12 @@ export class ConversationExtractor {
         .safeParse(entries)
 
       if (!parseResult.success) {
+        if (entries.length === 0) {
+          ApiDiagnosticsWriter.writeFailure({
+            url,
+            errorType: 'empty_entries',
+          }).catch(() => {})
+        }
         logger.warn(`Entry validation failed for ${url}: ${parseResult.error.message}`)
         return null
       }
@@ -257,16 +283,22 @@ export class ConversationExtractor {
     }
   }
 
-  private ensureEntriesFormat(data: any): any[] {
+  private ensureEntriesFormat(data: any, url: string): any[] {
     if (Array.isArray(data)) {
       return data
     }
-    if (Array.isArray(data.entries) && data.entries.length > 0) {
+    if (data && Array.isArray(data.entries)) {
       return data.entries
     }
     if (data && (data.query_str || data.blocks)) {
       return [data]
     }
+
+    ApiDiagnosticsWriter.writeFailure({
+      url,
+      errorType: 'unknown_shape',
+    }).catch(() => {})
+
     return []
   }
 

--- a/src/utils/api-diagnostics.ts
+++ b/src/utils/api-diagnostics.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { logger } from './logger.js';
+
+export interface ApiDiagnosticEntry {
+  timestamp: string;
+  url: string;
+  errorType: 'unknown_shape' | 'zod_error' | 'empty_entries';
+  zodErrorPaths?: string[];
+}
+
+export class ApiDiagnosticsWriter {
+  private static readonly DEBUG_DIR = 'debug';
+  private static readonly LOG_FILE = 'api-diagnostics.jsonl';
+
+  static async writeFailure(entry: Omit<ApiDiagnosticEntry, 'timestamp'>): Promise<void> {
+    try {
+      const fullEntry: ApiDiagnosticEntry = {
+        timestamp: new Date().toISOString(),
+        ...entry,
+      };
+
+      await fs.mkdir(this.DEBUG_DIR, { recursive: true });
+      const logPath = path.join(this.DEBUG_DIR, this.LOG_FILE);
+
+      await fs.appendFile(logPath, JSON.stringify(fullEntry) + '\n', 'utf8');
+    } catch (error) {
+      logger.warn(`Failed to write API diagnostic: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}

--- a/test/unit/api-diagnostics.unit.test.ts
+++ b/test/unit/api-diagnostics.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApiDiagnosticsWriter } from '../../src/utils/api-diagnostics.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+vi.mock('node:fs/promises');
+
+describe('ApiDiagnosticsWriter (Unit)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should write diagnostic entry to jsonl file', async () => {
+    const entry = {
+      url: 'http://test.com',
+      errorType: 'unknown_shape' as const,
+    };
+
+    await ApiDiagnosticsWriter.writeFailure(entry);
+
+    expect(fs.mkdir).toHaveBeenCalledWith('debug', { recursive: true });
+    expect(fs.appendFile).toHaveBeenCalledWith(
+      path.join('debug', 'api-diagnostics.jsonl'),
+      expect.stringContaining('"url":"http://test.com"'),
+      'utf8'
+    );
+    expect(fs.appendFile).toHaveBeenCalledWith(
+      path.join('debug', 'api-diagnostics.jsonl'),
+      expect.stringContaining('"errorType":"unknown_shape"'),
+      'utf8'
+    );
+  });
+
+  it('should include zodErrorPaths when provided', async () => {
+    const entry = {
+      url: 'http://test.com',
+      errorType: 'zod_error' as const,
+      zodErrorPaths: ['entries.0.title'],
+    };
+
+    await ApiDiagnosticsWriter.writeFailure(entry);
+
+    expect(fs.appendFile).toHaveBeenCalledWith(
+      path.join('debug', 'api-diagnostics.jsonl'),
+      expect.stringContaining('"zodErrorPaths":["entries.0.title"]'),
+      'utf8'
+    );
+  });
+});

--- a/test/unit/conversation-extractor.unit.test.ts
+++ b/test/unit/conversation-extractor.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConversationExtractor } from '../../src/scraper/conversation-extractor.js';
+import { ApiDiagnosticsWriter } from '../../src/utils/api-diagnostics.js';
+import type { BrowserContext } from '@playwright/test';
+
+vi.mock('../../src/utils/api-diagnostics.js', () => ({
+  ApiDiagnosticsWriter: {
+    writeFailure: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('ConversationExtractor (Unit)', () => {
+  let extractor: ConversationExtractor;
+  let mockContext: BrowserContext;
+
+  beforeEach(() => {
+    mockContext = {
+      newPage: vi.fn(),
+      pages: vi.fn(),
+    } as unknown as BrowserContext;
+    extractor = new ConversationExtractor(mockContext);
+    vi.clearAllMocks();
+  });
+
+  describe('ensureEntriesFormat', () => {
+    it('should return array if input is array', () => {
+      const data = [{ query_str: 'test' }];
+      const result = (extractor as any).ensureEntriesFormat(data, 'http://test.com');
+      expect(result).toEqual(data);
+      expect(ApiDiagnosticsWriter.writeFailure).not.toHaveBeenCalled();
+    });
+
+    it('should return data.entries if input has entries array', () => {
+      const data = { entries: [{ query_str: 'test' }] };
+      const result = (extractor as any).ensureEntriesFormat(data, 'http://test.com');
+      expect(result).toEqual(data.entries);
+      expect(ApiDiagnosticsWriter.writeFailure).not.toHaveBeenCalled();
+    });
+
+    it('should return [data] if input has query_str', () => {
+      const data = { query_str: 'test' };
+      const result = (extractor as any).ensureEntriesFormat(data, 'http://test.com');
+      expect(result).toEqual([data]);
+      expect(ApiDiagnosticsWriter.writeFailure).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array and call diagnostics for unknown shape', () => {
+      const data = { foo: 'bar' };
+      const result = (extractor as any).ensureEntriesFormat(data, 'http://test.com');
+      expect(result).toEqual([]);
+      expect(ApiDiagnosticsWriter.writeFailure).toHaveBeenCalledWith({
+        url: 'http://test.com',
+        errorType: 'unknown_shape',
+      });
+    });
+  });
+
+  describe('parseConversationData', () => {
+    it('should return null and call diagnostics if entries are empty', () => {
+      const data = { entries: [] };
+      const result = extractor.parseConversationData(data, 'http://test.com');
+      expect(result).toBeNull();
+      expect(ApiDiagnosticsWriter.writeFailure).toHaveBeenCalledWith({
+        url: 'http://test.com',
+        errorType: 'empty_entries',
+      });
+    });
+
+    it('should parse valid entries correctly', () => {
+      const data = {
+        entries: [
+          {
+            thread_title: 'Test Thread',
+            query_str: 'What is 1+1?',
+            blocks: [{ markdown_block: { answer: '2' } }],
+          },
+        ],
+      };
+      const result = extractor.parseConversationData(data, 'https://perplexity.ai/search/uuid');
+      expect(result).not.toBeNull();
+      expect(result?.title).toBe('Test Thread');
+      expect(result?.content).toContain('What is 1+1?');
+      expect(result?.content).toContain('2');
+    });
+  });
+});
+
+describe('ApiDiagnosticsWriter (Unit)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exist and have writeFailure method', () => {
+    expect(ApiDiagnosticsWriter.writeFailure).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR addresses issues with the Perplexity.ai scraper by:
1. Handling paginated API responses in `ConversationExtractor` to ensure full conversation history is captured.
2. Introducing a non-sensitive API diagnostic logging system (`ApiDiagnosticsWriter`) that appends failures to `debug/api-diagnostics.jsonl`.
3. Updating Zod schemas to match the actual API response format.
4. Adding unit tests for the new and modified components.
5. Updating documentation and `.gitignore`.

---
*PR created automatically by Jules for task [5954961572447595827](https://jules.google.com/task/5954961572447595827) started by @simwai*