### PR TITLE
Implement optional and conditional HyDE strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,13 @@ HEADLESS=false
 # Debugging
 # Set to 'true' to enable detailed API diagnostic logging in debug/api-diagnostics.jsonl
 DEBUG=false
+
+# HyDE (Hypothetical Document Embeddings)
+# HYDE_MODE: 'off' | 'fusion' | 'supplement' | 'auto'
+# - off: No HyDE is used.
+# - fusion: Always use HyDE and fuse with original results (old default).
+# - supplement: Only use HyDE if initial results are weak (new default).
+# - auto: Currently same as supplement.
+HYDE_MODE=supplement
+HYDE_THRESHOLD_SCORE=0.7
+HYDE_THRESHOLD_COUNT=5

--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,10 @@ HEADLESS=false
 DEBUG=false
 
 # HyDE (Hypothetical Document Embeddings)
-# HYDE_MODE: 'off' | 'fusion' | 'supplement' | 'auto'
+# HYDE_MODE: 'off' | 'fusion' | 'supplement'
 # - off: No HyDE is used.
 # - fusion: Always use HyDE and fuse with original results (old default).
 # - supplement: Only use HyDE if initial results are weak (new default).
-# - auto: Currently same as supplement.
 HYDE_MODE=supplement
 HYDE_THRESHOLD_SCORE=0.7
 HYDE_THRESHOLD_COUNT=5

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This tool is designed to externalize your Perplexity.ai conversation history int
 - **Parallelized Extraction**: Leverages Playwright to extract multiple conversation threads simultaneously for high-velocity data retrieval.
 - **Architectural Resilience**: Automatically restores browser contexts and retries operations, ensuring continuity amidst environmental instability.
 - **Advanced RAG (Retrieval-Augmented Generation)**: Engage in a cognitive dialogue with your history. The system employs intent analysis to synthesize broad summaries or pinpoint specific technical insights.
-- **HyDE (Hypothetical Document Embeddings)**: Before searching, the planner generates a hypothetical answer passage and uses it as an additional search vector, improving recall when your question wording differs from how you originally wrote things.
+- **HyDE (Hypothetical Document Embeddings)**: An optional retrieval enhancement that generates a hypothetical answer to improve semantic matching. Highly configurable (off, fusion, or supplement modes) via environment variables to balance precision and recall.
 - **Cross-Encoder Reranking**: After initial retrieval, a local ONNX cross-encoder (`ms-marco-MiniLM-L-6-v2`) rescores the top candidates by jointly reasoning over query and passage, surfacing the most relevant results before synthesis.
 - **Semantic Vector Search**: Move beyond keyword matching. Locate information based on conceptual depth and semantic relevance.
 - **Persistent State Tracking**: Frequent checkpoints allow the system to resume progress after any interruption.
@@ -151,7 +151,7 @@ The RAG modality is engineered for various levels of cognitive inquiry:
 
 The pipeline runs three enhancement stages automatically:
 
-1. **HyDE**: The planner writes a hypothetical answer passage and uses it as an extra search vector alongside your query variations, improving recall when question wording diverges from stored content.
+1. **HyDE**: Depending on the `HYDE_MODE` (default: `supplement`), the system may generate a hypothetical answer passage to bridge the lexical gap between questions and historical content. In `supplement` mode, it only activates if initial semantic searches yield weak results.
 2. **Expanded pool**: Precise mode retrieves 35 candidates (up from 20), exhaustive mode retrieves 60.
 3. **Cross-encoder reranking**: A local ONNX model (`Xenova/ms-marco-MiniLM-L-6-v2`) jointly scores each (query, passage) pair and reorders before synthesis. Activates automatically after `pnpm install`. First run downloads ~85MB model, cached thereafter.
 

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -129,8 +129,13 @@ Our architecture is informed by several key papers and concepts in the field of 
 
 ### Hypothetical Document Embeddings (HyDE)
 
-- **HyDE**: Rather than embedding the raw query, the LLM first generates a hypothetical document that would answer the query, then that document is embedded for retrieval. This closes the lexical gap between question phrasing and answer phrasing in the vector space.
-  - _Reference:_ [Gao et al., 2022. Precise Zero-Shot Dense Retrieval without Relevance Labels.](https://arxiv.org/abs/2212.10496)
+HyDE improves retrieval by generating a hypothetical answer to a query before embedding it, closing the lexical gap between questions and historical documents. Our implementation is highly configurable via `HYDE_MODE`:
+
+- **Off**: Standard semantic search only.
+- **Fusion**: (Traditional HyDE) Always generate a passage and fuse results using RRF.
+- **Supplement**: (Default) Perform initial semantic search first. Only trigger HyDE if results are weak (score < `HYDE_THRESHOLD_SCORE` or count < `HYDE_THRESHOLD_COUNT`). This maximizes accuracy while minimizing LLM latency.
+
+_Reference:_ [Gao et al., 2022. Precise Zero-Shot Dense Retrieval without Relevance Labels.](https://arxiv.org/abs/2212.10496)
 
 ### Cross-Encoder Reranking
 
@@ -205,7 +210,7 @@ Plain-language definitions for every technical term used in this document.
 | **Sparse Retrieval** | Search by exact keywords or strings (e.g. ripgrep). Perfect for finding specific names, IDs, or code snippets that embeddings might miss. |
 | **Hybrid Search** | Combining dense (meaning) and sparse (keyword) retrieval so you get the benefits of both. |
 | **RRF** (Reciprocal Rank Fusion) | A formula for merging ranked lists from multiple search methods into one combined ranking. It rewards results that appear near the top in multiple lists, without needing to normalize scores. |
-| **HyDE** (Hypothetical Document Embeddings) | Before searching, ask the LLM: "What would a good answer to this question look like?" Then search using *that* hypothetical answer instead of the raw question. Helps when your question phrasing doesn't match how the answer was originally written. |
+| **HyDE** (Hypothetical Document Embeddings) | Before searching, ask the LLM: "What would a good answer to this question look like?" Then search using *that* hypothetical answer instead of the raw question. Helps when your question phrasing doesn't match how the answer was originally written. Configurable via `HYDE_MODE` (off, fusion, supplement). |
 | **MapReduce** | A two-step processing pattern: **Map** = process many small chunks independently in parallel; **Reduce** = combine all those results into one final output. Used here to extract facts from many snippets without overloading the LLM's context window. |
 | **Context Window** | The maximum amount of text an LLM can read and reason about at once. Stuffing too many search results in at once causes the model to "lose" information in the middle; we use MapReduce to mitigate this. |
 | **Lost in the Middle** | A known LLM failure mode: when given a very long input, the model tends to remember the start and end well but forgets details buried in the middle. MapReduce mitigates this by processing small chunks. |

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -26,7 +26,7 @@ This document describes how the benchmark system works, which metrics it capture
 
 ## 1. Overview
 
-The benchmark system is a **latency and reliability stress test** for the full RAG pipeline. It fires a set of realistic queries end-to-end (through HyDE generation, hybrid search, cross-encoder reranking, MapReduce fact extraction, and final synthesis) and reports how long each stage takes and whether it completes without error.
+The benchmark system is a **latency and reliability stress test** for the full RAG pipeline. It fires a set of realistic queries end-to-end (through query refinement, optional HyDE expansion, hybrid search, cross-encoder reranking, MapReduce fact extraction, and final synthesis) and reports how long each stage takes and whether it completes without error.
 
 The goal is to give you a single command that answers: _"Is the pipeline fast and stable on my machine, with my data?"_
 
@@ -91,8 +91,10 @@ Together they cover the main failure modes: missed recall, entity blindness, pla
 The timer starts immediately before `orchestrator.answerQuestion(query)` is called and stops when it resolves. This captures the **full pipeline cost**:
 
 ```
-HyDE generation (LLM call)
-  → Hybrid search (vector + ripgrep)
+Query refinement (LLM call)
+  → Initial semantic search (vector)
+  → Optional HyDE generation (LLM call, if results are weak)
+  → Hybrid search fusion (vector + ripgrep)
   → RRF fusion
   → Cross-encoder reranking (ONNX inference)
   → MapReduce fact extraction (LLM batch calls)

--- a/src/ai/rag-orchestrator.ts
+++ b/src/ai/rag-orchestrator.ts
@@ -228,7 +228,7 @@ Return JSON: ${jsonTemplate}
       logger.debug(`Executing HyDE search (fusion): "${plan.hydePassage.slice(0, 60)}..."`)
       const hydeResults = await this.vectorStore.search(plan.hydePassage, 40)
       searchPools.push(hydeResults)
-    } else if (hydeMode === 'supplement' || hydeMode === 'auto') {
+    } else if (hydeMode === 'supplement') {
       const mergedSoFar = this.mergeAndFusionRank(searchPools)
       const maxScore = mergedSoFar.reduce((max, res) => Math.max(max, res.score), 0)
       const resultCount = mergedSoFar.length

--- a/src/ai/rag-orchestrator.ts
+++ b/src/ai/rag-orchestrator.ts
@@ -35,6 +35,7 @@ async function getCrossEncoder() {
 }
 
 interface ResearchPlan {
+  originalQuestion: string
   strategy: 'precise' | 'exhaustive'
   queries: string[]
   hardKeywords: string[]
@@ -171,19 +172,29 @@ INSTRUCTIONS:
   }
 
   private async developResearchPlan(originalQuestion: string): Promise<ResearchPlan> {
+    const isHydeInPlanner = this.config.hydeMode === 'fusion'
+    const hydeInstruction = isHydeInPlanner
+      ? '4. HyDE: Write 1-2 sentences that would plausibly appear in a saved answer to this question. Write as if it\'s content already stored, not as a reply.'
+      : ''
+
+    const jsonTemplate = isHydeInPlanner
+      ? '{"strategy": "...", "queries": [], "hardKeywords": [], "hydePassage": "...", "filters": {}}'
+      : '{"strategy": "...", "queries": [], "hardKeywords": [], "filters": {}}'
+
     const plannerPrompt = `
 Analyze: "${originalQuestion}"
 1. Strategy: "precise" (specific facts) or "exhaustive" (broad summary/entity history).
 2. Variations: 3 semantic search phrases.
 3. Hard Keywords: Identify any names, IDs, or unique technical terms for exact matching.
-4. HyDE: Write 1-2 sentences that would plausibly appear in a saved answer to this question. Write as if it's content already stored, not as a reply.
-Return JSON: {"strategy": "...", "queries": [], "hardKeywords": [], "hydePassage": "...", "filters": {}}
+${hydeInstruction}
+Return JSON: ${jsonTemplate}
 `
     try {
       const response = await this.ollamaClient.generate(plannerPrompt)
       const planJson = this.parseJsonFromResponse(response, {})
 
       return {
+        originalQuestion,
         strategy: planJson.strategy || 'precise',
         queries: planJson.queries || [originalQuestion],
         hardKeywords: planJson.hardKeywords || [],
@@ -193,6 +204,7 @@ Return JSON: {"strategy": "...", "queries": [], "hardKeywords": [], "hydePassage
     } catch (error) {
       return {
         strategy: 'precise',
+        originalQuestion,
         queries: [originalQuestion],
         hardKeywords: [],
         hydePassage: '',
@@ -203,6 +215,7 @@ Return JSON: {"strategy": "...", "queries": [], "hardKeywords": [], "hydePassage
 
   private async executeAdaptiveHybridSearch(plan: ResearchPlan): Promise<VectorSearchResult[]> {
     const searchPools: VectorSearchResult[][] = []
+    const hydeMode = this.config.hydeMode
 
     for (let i = 0; i < (plan.queries || []).length; i++) {
       const searchQuery = plan.queries[i]!
@@ -211,10 +224,30 @@ Return JSON: {"strategy": "...", "queries": [], "hardKeywords": [], "hydePassage
       searchPools.push(vectorResults)
     }
 
-    if (plan.hydePassage) {
-      logger.debug(`Executing HyDE search: "${plan.hydePassage.slice(0, 60)}..."`)
+    if (hydeMode === 'fusion' && plan.hydePassage) {
+      logger.debug(`Executing HyDE search (fusion): "${plan.hydePassage.slice(0, 60)}..."`)
       const hydeResults = await this.vectorStore.search(plan.hydePassage, 40)
       searchPools.push(hydeResults)
+    } else if (hydeMode === 'supplement' || hydeMode === 'auto') {
+      const mergedSoFar = this.mergeAndFusionRank(searchPools)
+      const maxScore = mergedSoFar.reduce((max, res) => Math.max(max, res.score), 0)
+      const resultCount = mergedSoFar.length
+
+      const isWeak =
+        maxScore < this.config.hydeThresholdScore || resultCount < this.config.hydeThresholdCount
+
+      if (isWeak) {
+        logger.info(
+          `Initial results weak (score: ${maxScore.toFixed(2)}, count: ${resultCount}). Triggering HyDE supplement...`
+        )
+        const hydePassage =
+          plan.hydePassage || (await this.generateHydePassage(plan.originalQuestion))
+        if (hydePassage) {
+          logger.debug(`Executing HyDE search (supplement): "${hydePassage.slice(0, 60)}..."`)
+          const hydeResults = await this.vectorStore.search(hydePassage, 40)
+          searchPools.push(hydeResults)
+        }
+      }
     }
 
     const keywordMatchPool: VectorSearchResult[] = []
@@ -383,6 +416,18 @@ Return JSON array: [{"fact": "...", "node_id": N, "thread": "..."}]
     }
 
     return extractedFindings
+  }
+
+  private async generateHydePassage(question: string): Promise<string> {
+    const hydePrompt = `
+Write 1-2 sentences that would plausibly appear in a saved answer to the question: "${question}"
+Write as if it's content already stored in a document, not as a direct reply.
+`
+    try {
+      return await this.ollamaClient.generate(hydePrompt)
+    } catch (error) {
+      return ''
+    }
   }
 
   private async generateMightiestResponse(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -24,6 +24,9 @@ const configSchema = z.object({
     .transform((val) => val === 'true'),
   headless: z.union([z.boolean(), z.literal('new')]),
   debug: z.boolean(),
+  hydeMode: z.enum(['off', 'fusion', 'supplement', 'auto']),
+  hydeThresholdScore: z.number(),
+  hydeThresholdCount: z.number().int().nonnegative(),
   exportStrategies: z
     .string()
     .optional()
@@ -65,6 +68,9 @@ function parseEnvConfig(): Config {
     enableVectorSearch: process.env['ENABLE_VECTOR_SEARCH'],
     headless: headless,
     debug: process.env['DEBUG'] === 'true',
+    hydeMode: (process.env['HYDE_MODE'] || 'supplement') as any,
+    hydeThresholdScore: parseFloat(process.env['HYDE_THRESHOLD_SCORE'] || '0.7'),
+    hydeThresholdCount: parseInt(process.env['HYDE_THRESHOLD_COUNT'] || '5', 10),
     exportStrategies: process.env['EXPORT_STRATEGIES'],
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -24,7 +24,7 @@ const configSchema = z.object({
     .transform((val) => val === 'true'),
   headless: z.union([z.boolean(), z.literal('new')]),
   debug: z.boolean(),
-  hydeMode: z.enum(['off', 'fusion', 'supplement', 'auto']),
+  hydeMode: z.enum(['off', 'fusion', 'supplement']),
   hydeThresholdScore: z.number(),
   hydeThresholdCount: z.number().int().nonnegative(),
   exportStrategies: z

--- a/test/unit/hyde-mode.unit.test.ts
+++ b/test/unit/hyde-mode.unit.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RagOrchestrator } from '../../src/ai/rag-orchestrator.js'
+import { VectorStore } from '../../src/search/vector-store.js'
+import { OllamaClient } from '../../src/ai/ollama-client.js'
+import { RgSearch } from '../../src/search/rg-search.js'
+
+vi.mock('../../src/search/vector-store.js')
+vi.mock('../../src/ai/ollama-client.js')
+vi.mock('../../src/search/rg-search.js')
+vi.mock('../../src/utils/logger.js')
+
+describe('RagOrchestrator HyDE Modes', () => {
+  let config: any
+  let orchestrator: any
+  let mockVectorStore: any
+  let mockOllamaClient: any
+
+  beforeEach(() => {
+    config = {
+      hydeMode: 'supplement',
+      hydeThresholdScore: 0.7,
+      hydeThresholdCount: 5,
+      ollamaModel: 'test-model',
+      exportDir: 'exports'
+    }
+    mockVectorStore = new VectorStore(config)
+    mockOllamaClient = new OllamaClient(config)
+
+    orchestrator = new RagOrchestrator(config)
+    orchestrator.vectorStore = mockVectorStore
+    orchestrator.ollamaClient = mockOllamaClient
+    orchestrator.ripgrep = new RgSearch(config)
+
+    // Default mocks
+    mockOllamaClient.generate.mockResolvedValue(JSON.stringify({
+      strategy: 'precise',
+      queries: ['query1'],
+      hardKeywords: [],
+      hydePassage: 'hypothetical passage'
+    }))
+    mockVectorStore.search.mockResolvedValue([])
+  })
+
+  it('should NOT trigger HyDE when mode is "off"', async () => {
+    config.hydeMode = 'off'
+    const plan = await orchestrator.developResearchPlan('test question')
+    await orchestrator.executeAdaptiveHybridSearch(plan)
+
+    expect(mockVectorStore.search).toHaveBeenCalledTimes(1)
+    expect(mockVectorStore.search).not.toHaveBeenCalledWith('hypothetical passage', 40)
+  })
+
+  it('should ALWAYS trigger HyDE when mode is "fusion"', async () => {
+    config.hydeMode = 'fusion'
+    const plan = await orchestrator.developResearchPlan('test question')
+    await orchestrator.executeAdaptiveHybridSearch(plan)
+
+    expect(mockVectorStore.search).toHaveBeenCalledTimes(2) // 1 query + 1 hyde
+    expect(mockVectorStore.search).toHaveBeenCalledWith('hypothetical passage', 40)
+  })
+
+  it('should trigger HyDE in supplement mode when results are weak', async () => {
+    config.hydeMode = 'supplement'
+    mockVectorStore.search.mockResolvedValueOnce([
+      { meta: { id: '1', score: 0.5 }, score: 0.5 }
+    ])
+    mockVectorStore.search.mockResolvedValueOnce([]) // HyDE results
+
+    const plan = await orchestrator.developResearchPlan('test question')
+    await orchestrator.executeAdaptiveHybridSearch(plan)
+
+    expect(mockVectorStore.search).toHaveBeenCalledTimes(2)
+  })
+
+  it('should NOT trigger HyDE in supplement mode when results are strong', async () => {
+    config.hydeMode = 'supplement'
+    mockVectorStore.search.mockResolvedValueOnce([
+      { meta: { id: '1' }, score: 0.9 },
+      { meta: { id: '2' }, score: 0.8 },
+      { meta: { id: '3' }, score: 0.8 },
+      { meta: { id: '4' }, score: 0.8 },
+      { meta: { id: '5' }, score: 0.8 },
+      { meta: { id: '6' }, score: 0.8 }
+    ])
+
+    const plan = await orchestrator.developResearchPlan('test question')
+    await orchestrator.executeAdaptiveHybridSearch(plan)
+
+    expect(mockVectorStore.search).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
This PR introduces a configurable HyDE (Hypothetical Document Embeddings) strategy to the RAG pipeline. Users can now choose between:
- 'off': Disables HyDE entirely.
- 'fusion': Always uses HyDE (original behavior).
- 'supplement' (Default): A cascading fallback that only triggers HyDE generation if initial semantic search results are weak, saving latency and avoiding vector drift.

Includes environment variable support, updated architecture docs, and new unit tests.

---
*PR created automatically by Jules for task [1819030149412361629](https://jules.google.com/task/1819030149412361629) started by @simwai*